### PR TITLE
Fix scrollView zoom to infinity warning

### DIFF
--- a/Sources/ImageViewerController.swift
+++ b/Sources/ImageViewerController.swift
@@ -222,6 +222,10 @@ class ImageViewerController:UIViewController, UIGestureRecognizerDelegate {
 extension ImageViewerController {
     
     func updateMinMaxZoomScaleForSize(_ size: CGSize) {
+        if imageView.bounds.width == 0 || imageView.bounds.height == 0 {
+            return
+        }
+        
         let minScale = min(
             size.width/imageView.bounds.width,
             size.height/imageView.bounds.height)


### PR DESCRIPTION
Hi, thanks for the library. I added a fix for the warning "UIScrollView is ignoring an attempt to set zoomScale to a non-finite value: inf", by checking if image view bounds width or height is zero before setting scrollView zoom.