### PR TITLE
Update visibility of ImageCarouselViewController to public

### DIFF
--- a/Sources/ImageCarouselViewController.swift
+++ b/Sources/ImageCarouselViewController.swift
@@ -5,7 +5,7 @@ public protocol ImageDataSource:class {
     func imageItem(at index:Int) -> ImageItem
 }
 
-class ImageCarouselViewController:UIPageViewController, ImageViewerTransitionViewControllerConvertible {
+public class ImageCarouselViewController:UIPageViewController, ImageViewerTransitionViewControllerConvertible {
     
     unowned var initialSourceView: UIImageView?
     var sourceView: UIImageView? {


### PR DESCRIPTION
It allows using ImageCarouselViewController outside of this package. For example, to use viewController present without animation (`myViewController.present(imageCarousel, animated: false, completion: nil)`) or use it in another extension/helper.