### PR TITLE
Add ImageLoader protocol for handling loading of remote images

### DIFF
--- a/ImageViewer.swift.xcodeproj/project.pbxproj
+++ b/ImageViewer.swift.xcodeproj/project.pbxproj
@@ -13,12 +13,12 @@
 		3FBC5E8F24E5910E00E68938 /* UINavigationBar_Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBC5E8324E5910E00E68938 /* UINavigationBar_Extensions.swift */; };
 		3FBC5E9024E5910E00E68938 /* ImageCarouselViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBC5E8424E5910E00E68938 /* ImageCarouselViewController.swift */; };
 		3FBC5E9124E5910E00E68938 /* ImageViewerOption.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBC5E8524E5910E00E68938 /* ImageViewerOption.swift */; };
-		3FBC5E9224E5910E00E68938 /* RightNavItemDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBC5E8624E5910E00E68938 /* RightNavItemDelegate.swift */; };
 		3FBC5E9324E5910E00E68938 /* ImageItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBC5E8724E5910E00E68938 /* ImageItem.swift */; };
 		3FBC5E9424E5910E00E68938 /* ImageViewerTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBC5E8824E5910E00E68938 /* ImageViewerTheme.swift */; };
 		3FBC5E9524E5910E00E68938 /* ImageViewerController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBC5E8924E5910E00E68938 /* ImageViewerController.swift */; };
 		3FBC5E9624E5910E00E68938 /* SimpleImageDatasource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FBC5E8A24E5910E00E68938 /* SimpleImageDatasource.swift */; };
 		3FBC5E9D24E595AB00E68938 /* SDWebImage.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3FBC5E9C24E595AB00E68938 /* SDWebImage.framework */; };
+		CB0EEA2E261612E400E9B9CB /* ImageViewerTransitionPresentationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB0EEA2D261612E400E9B9CB /* ImageViewerTransitionPresentationManager.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -29,13 +29,13 @@
 		3FBC5E8324E5910E00E68938 /* UINavigationBar_Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UINavigationBar_Extensions.swift; sourceTree = "<group>"; };
 		3FBC5E8424E5910E00E68938 /* ImageCarouselViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageCarouselViewController.swift; sourceTree = "<group>"; };
 		3FBC5E8524E5910E00E68938 /* ImageViewerOption.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageViewerOption.swift; sourceTree = "<group>"; };
-		3FBC5E8624E5910E00E68938 /* RightNavItemDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RightNavItemDelegate.swift; sourceTree = "<group>"; };
 		3FBC5E8724E5910E00E68938 /* ImageItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageItem.swift; sourceTree = "<group>"; };
 		3FBC5E8824E5910E00E68938 /* ImageViewerTheme.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageViewerTheme.swift; sourceTree = "<group>"; };
 		3FBC5E8924E5910E00E68938 /* ImageViewerController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageViewerController.swift; sourceTree = "<group>"; };
 		3FBC5E8A24E5910E00E68938 /* SimpleImageDatasource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SimpleImageDatasource.swift; sourceTree = "<group>"; };
 		3FBC5E9924E591CB00E68938 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		3FBC5E9C24E595AB00E68938 /* SDWebImage.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SDWebImage.framework; path = Carthage/Build/iOS/SDWebImage.framework; sourceTree = SOURCE_ROOT; };
+		CB0EEA2D261612E400E9B9CB /* ImageViewerTransitionPresentationManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ImageViewerTransitionPresentationManager.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -77,11 +77,11 @@
 				3FBC5E8324E5910E00E68938 /* UINavigationBar_Extensions.swift */,
 				3FBC5E8424E5910E00E68938 /* ImageCarouselViewController.swift */,
 				3FBC5E8524E5910E00E68938 /* ImageViewerOption.swift */,
-				3FBC5E8624E5910E00E68938 /* RightNavItemDelegate.swift */,
 				3FBC5E8724E5910E00E68938 /* ImageItem.swift */,
 				3FBC5E8824E5910E00E68938 /* ImageViewerTheme.swift */,
 				3FBC5E8924E5910E00E68938 /* ImageViewerController.swift */,
 				3FBC5E8A24E5910E00E68938 /* SimpleImageDatasource.swift */,
+				CB0EEA2D261612E400E9B9CB /* ImageViewerTransitionPresentationManager.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -206,12 +206,12 @@
 			files = (
 				3FBC5E9024E5910E00E68938 /* ImageCarouselViewController.swift in Sources */,
 				3FBC5E9424E5910E00E68938 /* ImageViewerTheme.swift in Sources */,
+				CB0EEA2E261612E400E9B9CB /* ImageViewerTransitionPresentationManager.swift in Sources */,
 				3FBC5E9524E5910E00E68938 /* ImageViewerController.swift in Sources */,
 				3FBC5E8E24E5910E00E68938 /* UIView_Extensions.swift in Sources */,
 				3FBC5E9624E5910E00E68938 /* SimpleImageDatasource.swift in Sources */,
 				3FBC5E8C24E5910E00E68938 /* UIImageView_Extensions.swift in Sources */,
 				3FBC5E9124E5910E00E68938 /* ImageViewerOption.swift in Sources */,
-				3FBC5E9224E5910E00E68938 /* RightNavItemDelegate.swift in Sources */,
 				3FBC5E9324E5910E00E68938 /* ImageItem.swift in Sources */,
 				3FBC5E8F24E5910E00E68938 /* UINavigationBar_Extensions.swift in Sources */,
 			);

--- a/Sources/ImageCarouselViewController.swift
+++ b/Sources/ImageCarouselViewController.swift
@@ -23,6 +23,7 @@ public class ImageCarouselViewController:UIPageViewController, ImageViewerTransi
     }
     
     weak var imageDatasource:ImageDataSource?
+    let imageLoader:ImageLoader
  
     var initialIndex = 0
     
@@ -59,6 +60,7 @@ public class ImageCarouselViewController:UIPageViewController, ImageViewerTransi
     public init(
         sourceView:UIImageView,
         imageDataSource: ImageDataSource?,
+        imageLoader: ImageLoader,
         options:[ImageViewerOption] = [],
         initialIndex:Int = 0) {
         
@@ -66,6 +68,7 @@ public class ImageCarouselViewController:UIPageViewController, ImageViewerTransi
         self.initialIndex = initialIndex
         self.options = options
         self.imageDatasource = imageDataSource
+        self.imageLoader = imageLoader
         let pageOptions = [UIPageViewController.OptionsKey.interPageSpacing: 20]
         super.init(
             transitionStyle: .scroll,
@@ -141,7 +144,8 @@ public class ImageCarouselViewController:UIPageViewController, ImageViewerTransi
         if let imageDatasource = imageDatasource {
             let initialVC:ImageViewerController = .init(
                 index: initialIndex,
-                imageItem: imageDatasource.imageItem(at: initialIndex))
+                imageItem: imageDatasource.imageItem(at: initialIndex),
+                imageLoader: imageLoader)
             setViewControllers([initialVC], direction: .forward, animated: true)
         }
     }
@@ -192,7 +196,8 @@ extension ImageCarouselViewController:UIPageViewControllerDataSource {
         let newIndex = vc.index - 1
         return ImageViewerController.init(
             index: newIndex,
-            imageItem:  imageDatasource.imageItem(at: newIndex))
+            imageItem:  imageDatasource.imageItem(at: newIndex),
+            imageLoader: vc.imageLoader)
     }
     
     public func pageViewController(
@@ -206,6 +211,7 @@ extension ImageCarouselViewController:UIPageViewControllerDataSource {
         let newIndex = vc.index + 1
         return ImageViewerController.init(
             index: newIndex,
-            imageItem: imageDatasource.imageItem(at: newIndex))
+            imageItem: imageDatasource.imageItem(at: newIndex),
+            imageLoader: vc.imageLoader)
     }
 }

--- a/Sources/ImageItem.swift
+++ b/Sources/ImageItem.swift
@@ -2,7 +2,5 @@ import UIKit
 
 public enum ImageItem {
     case image(UIImage?)
-    #if canImport(SDWebImage)
     case url(URL, placeholder: UIImage?)
-    #endif
 }

--- a/Sources/ImageLoader.swift
+++ b/Sources/ImageLoader.swift
@@ -1,0 +1,45 @@
+import Foundation
+#if canImport(SDWebImage)
+import SDWebImage
+#endif
+
+public protocol ImageLoader {
+    func loadImage(_ url: URL, placeholder: UIImage?, imageView: UIImageView, completion: @escaping (_ image: UIImage?) -> Void)
+}
+
+public struct URLSessionImageLoader: ImageLoader {
+    public init() {}
+
+    public func loadImage(_ url: URL, placeholder: UIImage?, imageView: UIImageView, completion: @escaping (UIImage?) -> Void) {
+        if let placeholder = placeholder {
+            imageView.image = placeholder
+        }
+
+        DispatchQueue.global(qos: .background).async {
+            guard let data = try? Data(contentsOf: url), let image = UIImage(data: data) else {
+                completion(nil)
+                return
+            }
+
+            DispatchQueue.main.async {
+                imageView.image = image
+            }
+        }
+    }
+}
+
+#if canImport(SDWebImage)
+struct SDWebImageLoader: ImageLoader {
+    func loadImage(_ url: URL, placeholder: UIImage?, imageView: UIImageView, completion: @escaping (UIImage?) -> Void) {
+        imageView.sd_setImage(
+            with: url,
+            placeholderImage: placeholder,
+            options: [],
+            progress: nil) {(img, err, type, url) in
+                DispatchQueue.main.async {
+                    completion(img)
+                }
+        }
+    }
+}
+#endif

--- a/Sources/ImageViewerController.swift
+++ b/Sources/ImageViewerController.swift
@@ -1,13 +1,11 @@
 import UIKit
-#if canImport(SDWebImage)
-import SDWebImage
-#endif
 
 class ImageViewerController:UIViewController,
 UIGestureRecognizerDelegate {
     
     var imageView: UIImageView = UIImageView(frame: .zero)
-
+    let imageLoader: ImageLoader
+    
     var backgroundView:UIView? {
         guard let _parent = parent as? ImageCarouselViewController
             else { return nil}
@@ -37,10 +35,12 @@ UIGestureRecognizerDelegate {
     
     init(
         index: Int,
-        imageItem:ImageItem) {
-        
+        imageItem:ImageItem,
+        imageLoader: ImageLoader) {
+
         self.index = index
         self.imageItem = imageItem
+        self.imageLoader = imageLoader
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -88,18 +88,12 @@ UIGestureRecognizerDelegate {
         case .image(let img):
             imageView.image = img
             imageView.layoutIfNeeded()
-            #if canImport(SDWebImage)
         case .url(let url, let placeholder):
-            imageView.sd_setImage(
-                with: url,
-                placeholderImage: placeholder,
-                options: [],
-                progress: nil) {(img, err, type, url) in
-                    DispatchQueue.main.async {[weak self] in
-                        self?.layout()
-                    }
+            imageLoader.loadImage(url, placeholder: placeholder, imageView: imageView) { (image) in
+                DispatchQueue.main.async {[weak self] in
+                    self?.layout()
+                }
             }
-            #endif
         default:
             break
         }

--- a/Sources/UIImageView_Extensions.swift
+++ b/Sources/UIImageView_Extensions.swift
@@ -6,6 +6,7 @@ extension UIImageView {
     private class TapWithDataRecognizer:UITapGestureRecognizer {
         weak var from:UIViewController?
         var imageDatasource:ImageDataSource?
+        var imageLoader:ImageLoader?
         var initialIndex:Int = 0
         var options:[ImageViewerOption] = []
     }
@@ -18,20 +19,22 @@ extension UIImageView {
     
     public func setupImageViewer(
         options:[ImageViewerOption] = [],
-        from:UIViewController? = nil) {
+        from:UIViewController? = nil,
+        imageLoader:ImageLoader? = nil) {
         setup(
             datasource: SimpleImageDatasource(imageItems: [.image(image)]),
             options: options,
-            from: from)
+            from: from,
+            imageLoader: imageLoader)
     }
-    
-    #if canImport(SDWebImage)
+
     public func setupImageViewer(
         url:URL,
         initialIndex:Int = 0,
         placeholder: UIImage? = nil,
         options:[ImageViewerOption] = [],
-        from:UIViewController? = nil) {
+        from:UIViewController? = nil,
+        imageLoader:ImageLoader? = nil) {
         
         let datasource = SimpleImageDatasource(
             imageItems: [url].compactMap {
@@ -41,15 +44,16 @@ extension UIImageView {
             datasource: datasource,
             initialIndex: initialIndex,
             options: options,
-            from: from)
+            from: from,
+            imageLoader: imageLoader)
     }
-    #endif
     
     public func setupImageViewer(
         images:[UIImage],
         initialIndex:Int = 0,
         options:[ImageViewerOption] = [],
-        from:UIViewController? = nil) {
+        from:UIViewController? = nil,
+        imageLoader:ImageLoader? = nil) {
         
         let datasource = SimpleImageDatasource(
             imageItems: images.compactMap {
@@ -59,16 +63,17 @@ extension UIImageView {
             datasource: datasource,
             initialIndex: initialIndex,
             options: options,
-            from: from)
+            from: from,
+            imageLoader: imageLoader)
     }
-    
-    #if canImport(SDWebImage)
+
     public func setupImageViewer(
         urls:[URL],
         initialIndex:Int = 0,
         options:[ImageViewerOption] = [],
         placeholder: UIImage? = nil,
-        from:UIViewController? = nil) {
+        from:UIViewController? = nil,
+        imageLoader:ImageLoader? = nil) {
         
         let datasource = SimpleImageDatasource(
             imageItems: urls.compactMap {
@@ -78,28 +83,31 @@ extension UIImageView {
             datasource: datasource,
             initialIndex: initialIndex,
             options: options,
-            from: from)
+            from: from,
+            imageLoader: imageLoader)
     }
-    #endif
     
     public func setupImageViewer(
         datasource:ImageDataSource,
         initialIndex:Int = 0,
         options:[ImageViewerOption] = [],
-        from:UIViewController? = nil) {
+        from:UIViewController? = nil,
+        imageLoader:ImageLoader? = nil) {
         
         setup(
             datasource: datasource,
             initialIndex: initialIndex,
             options: options,
-            from: from)
+            from: from,
+            imageLoader: imageLoader)
     }
     
     private func setup(
         datasource:ImageDataSource?,
         initialIndex:Int = 0,
         options:[ImageViewerOption] = [],
-        from: UIViewController? = nil) {
+        from: UIViewController? = nil,
+        imageLoader:ImageLoader? = nil) {
         
         var _tapRecognizer:TapWithDataRecognizer?
         gestureRecognizers?.forEach {
@@ -121,6 +129,7 @@ extension UIImageView {
         }
         // Pass the Data
         _tapRecognizer!.imageDatasource = datasource
+        _tapRecognizer!.imageLoader = imageLoader
         _tapRecognizer!.initialIndex = initialIndex
         _tapRecognizer!.options = options
         _tapRecognizer!.from = from
@@ -133,6 +142,7 @@ extension UIImageView {
         let imageCarousel = ImageCarouselViewController.init(
             sourceView: sourceView,
             imageDataSource: sender.imageDatasource,
+            imageLoader: sender.imageLoader ?? URLSessionImageLoader(),
             options: sender.options,
             initialIndex: sender.initialIndex)
         let presentFromVC = sender.from ?? vc


### PR DESCRIPTION
This commit adds new protocol - ImageLoader and simple implementation
via Data(contentsOf: url). This simple implementation removes
the requirement to include heavy SDWebImage dependency, but still makes
it possible.

Additionally, this commit makes it possible for clients
to specify their own implementation of ImageLoader at call site.

Commit also removes non-existing RightNavItemDelegate.swift file
reference. And adds ImageViewerTransitionPresentationManager.swift,
which was omitted.